### PR TITLE
Add command ownership summary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3850,6 +3850,7 @@ dependencies = [
  "hex",
  "ic-agent",
  "ic-base-types",
+ "ic-ic00-types",
  "ic-sns-governance",
  "ic-types 0.3.0",
  "ledger-canister",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ hex = {version = "0.4.2", features = ["serde"] }
 ic-agent = "0.15.0"
 ic-base-types = { git = "https://github.com/dfinity/ic", rev = "9ccfb7c3ed424e907be2213c3bb18fb0bd740efb" }
 ic-sns-governance = { git = "https://github.com/dfinity/ic", rev = "9ccfb7c3ed424e907be2213c3bb18fb0bd740efb" }
+ic-ic00-types = { git = "https://github.com/dfinity/ic", rev = "9ccfb7c3ed424e907be2213c3bb18fb0bd740efb" }
 ic-types = "0.3.0"
 ledger-canister = { git = "https://github.com/dfinity/ic", rev = "9ccfb7c3ed424e907be2213c3bb18fb0bd740efb" }
 libsecp256k1 = "0.7.0"

--- a/candid/root.did
+++ b/candid/root.did
@@ -1,0 +1,24 @@
+type CanisterStatusResultV2 = record {
+  controller : principal;
+  status : CanisterStatusType_1;
+  freezing_threshold : nat;
+  balance : vec record { vec nat8; nat };
+  memory_size : nat;
+  cycles : nat;
+  settings : DefiniteCanisterSettingsArgs;
+  module_hash : opt vec nat8;
+};
+type CanisterStatusType_1 = variant { stopped; stopping; running };
+type DefiniteCanisterSettingsArgs = record {
+  controller : principal;
+  freezing_threshold : nat;
+  controllers : vec principal;
+  memory_allocation : nat;
+  compute_allocation : nat;
+};
+
+service : {
+    get_sns_canisters_summary : (vec principal) -> (
+        vec record { text; principal; CanisterStatusResultV2 },
+    );
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -14,6 +14,7 @@ mod qrcode;
 mod request_status;
 mod send;
 mod transfer;
+mod ownership_summary;
 
 use crate::SnsCanisterIds;
 
@@ -36,6 +37,9 @@ pub enum Command {
     /// Signs a ManageNeuron message to submit a UpgradeSnsControlledCanister
     /// proposal.
     MakeUpgradeCanisterProposal(make_upgrade_canister_proposal::MakeUpgradeCanisterProposalOpts),
+    /// Print a summary of the ownership of the sns canisters, takes the dapp canister id as an
+    /// argument.
+    OwnershipSummary(ownership_summary::OwnershipSummaryOps),
 }
 
 pub fn exec(
@@ -90,7 +94,12 @@ pub fn exec(
             let canister_ids = require_canister_ids(canister_ids)?;
             make_upgrade_canister_proposal::exec(&pem, &canister_ids, opts)
                 .and_then(|out| print_vec(qr, &out))
-        }
+        },
+        Command::OwnershipSummary(opts) => {
+            let pem = require_pem(pem)?;
+            let canister_ids = require_canister_ids(canister_ids)?;
+            runtime.block_on(async { ownership_summary::exec(&pem, &canister_ids, opts).await })
+        },
     }
 }
 

--- a/src/commands/ownership_summary.rs
+++ b/src/commands/ownership_summary.rs
@@ -1,0 +1,40 @@
+use crate::lib::{AnyhowResult, TargetCanister};
+use clap::Parser;
+use candid::Encode;
+use ic_base_types::PrincipalId;
+//use ic_ic00_types::{CanisterIdRecord, IC_00};
+use crate::SnsCanisterIds;
+use crate::commands::send::sign_send_and_check_status;
+use std::str::FromStr;
+
+#[derive(Parser, Debug)]
+#[clap(about, version, author)]
+pub struct OwnershipSummaryOps {
+
+    /// Canister id of the dapp.
+    #[clap(long)]
+    canister_id: String,
+
+    /// Will display the query, but not send it
+    #[clap(long)]
+    dry_run: bool,
+}
+
+
+
+pub async fn exec(private_key_pem: &str, sns_canister_ids: &SnsCanisterIds, opts: OwnershipSummaryOps) -> AnyhowResult {
+    let canister_id = PrincipalId::from_str(&opts.canister_id)?;
+    let root_canister_id = PrincipalId::from(sns_canister_ids.root_canister_id).0;
+
+    let args = Encode!(&vec![canister_id])?;
+
+    sign_send_and_check_status(
+        private_key_pem,
+        "get_sns_canisters_summary",
+        args.clone(),
+        opts.dry_run,
+        TargetCanister::Root(root_canister_id),
+    ).await?;
+
+    Ok(())
+}

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -42,6 +42,7 @@ pub type AnyhowResult<T = ()> = anyhow::Result<T>;
 pub enum TargetCanister {
     Governance(Principal),
     Ledger(Principal),
+    Root(Principal),
 }
 
 impl From<TargetCanister> for Principal {
@@ -49,6 +50,7 @@ impl From<TargetCanister> for Principal {
         match target_canister {
             TargetCanister::Governance(principal) => principal,
             TargetCanister::Ledger(principal) => principal,
+            TargetCanister::Root(principal) => principal,
         }
     }
 }
@@ -64,6 +66,10 @@ pub fn get_local_candid(target_canister: TargetCanister) -> AnyhowResult<String>
         TargetCanister::Ledger(_) => {
             String::from_utf8(include_bytes!("../../candid/ledger.did").to_vec())
                 .context("Cannot load ledger.did")
+        }
+        TargetCanister::Root(_) => {
+            String::from_utf8(include_bytes!("../../candid/root.did").to_vec())
+                .context("Cannot load root.did")
         }
     }
 }


### PR DESCRIPTION
Adds a new command ownership-summary to sns-quill. This will display a short summary of the sns canisters and their controller.